### PR TITLE
Change baseURL to HTTPS

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 languageCode: "en-us"
 title: "9hack Studios"
-baseURL: "cse125.ucsd.edu/2017/cse125g1/"
+baseURL: "//cse125.ucsd.edu/2017/cse125g1/"
 theme: "hyde"
 metaDataFormat: "yaml"
 canonifyURLs: true

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 languageCode: "en-us"
 title: "9hack Studios"
-baseURL: "https://cse125.ucsd.edu/2017/cse125g1/"
+baseURL: "cse125.ucsd.edu/2017/cse125g1/"
 theme: "hyde"
 metaDataFormat: "yaml"
 canonifyURLs: true

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 languageCode: "en-us"
 title: "9hack Studios"
-baseURL: "http://cse125.ucsd.edu/2017/cse125g1/"
+baseURL: "https://cse125.ucsd.edu/2017/cse125g1/"
 theme: "hyde"
 metaDataFormat: "yaml"
 canonifyURLs: true


### PR DESCRIPTION
cse125.ucsd.edu now forces HTTPS, causing requests for the CSS resources fail since they're made with HTTP.